### PR TITLE
Crude fix for skipping empty rows, avoiding high memory usage

### DIFF
--- a/lib/doc/workbook.js
+++ b/lib/doc/workbook.js
@@ -17,7 +17,7 @@ var CSV = require('./../csv/csv');
 //  Manage String table, Hyperlink table, etc.
 //  Manage scaffolding for contained objects to write to/read from
 
-var Workbook = module.exports = function() {
+var Workbook = module.exports = function(maxRows) {
   this.created = new Date();
   this.modified = this.created;
   this.properties = {};
@@ -25,11 +25,12 @@ var Workbook = module.exports = function() {
   this.views = [];
   this.media = [];
   this._definedNames = new DefinedNames();
+  this.maxRows = maxRows;
 };
 
 Workbook.prototype = {
   get xlsx() {
-    return this._xlsx || (this._xlsx = new XLSX(this));
+    return this._xlsx || (this._xlsx = new XLSX(this, this.maxRows));
   },
   get csv() {
     return this._csv || (this._csv = new CSV(this));

--- a/lib/xlsx/xform/base-xform.js
+++ b/lib/xlsx/xform/base-xform.js
@@ -58,11 +58,24 @@ BaseXform.prototype = {
     );
   },
 
-  parse: function(parser) {
+  parse: function(parser, stream) {
     var self = this;
     return new PromishLib.Promish(function(resolve, reject) {
       parser.on('opentag', function(node) {
-        self.parseOpen(node);
+        // Watch out for "The number of rows exceeds the limit" errors:
+        try {
+          self.parseOpen(node);
+        } catch (error) {
+          // Abandon ship! Prevent the parser from consuming any more resources
+          // and reject the rest of the stream.
+          // Unfortunately this cleanup code cannot be moved to the parseStream
+          // function -- since that doesn't kick in until the next tick,
+          // it's 10 seconds later in the example I'm looking at right now
+          parser.removeAllListeners();
+          stream.unpipe(parser);
+          stream.resume(); // Discard the rest of the XML stream
+          reject(error);
+        }
       });
       parser.on('text', function(text) {
         self.parseText(text);
@@ -82,7 +95,7 @@ BaseXform.prototype = {
   },
   parseStream: function(stream) {
     var parser = Sax.createStream(true, {});
-    var promise = this.parse(parser);
+    var promise = this.parse(parser, stream);
     stream.pipe(parser);
     return promise;
   },

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -15,6 +15,7 @@ var RowXform = module.exports = function() {
   this.map = {
     c: new CellXform()
   };
+  this.numRowsSeen = 0;
 };
 
 // <row r="<%=row.number%>"
@@ -76,32 +77,26 @@ utils.inherits(RowXform, BaseXform, {
   },
   
   parseOpen: function(node) {
-    if (node.name === 'row' && node.isSelfClosing) {
-      // We've seen some files that have up to a ~a million trailing rows
-      // that only seem to exist as placeholders for custom formats, eg.:
-      //
-      //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
-      //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
-      //
-      // Avoid spending memory on those rows by skipping them as soon as we
-      // notice that the XML tag is self-closing, and thus cannot contain any
-      // data we're interested in. For one file in particular,
-      // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
-
-      if (typeof this.numConsecutiveEmptyRows === 'undefined') {
-        this.numConsecutiveEmptyRows = 1;
-      } else {
-        this.numConsecutiveEmptyRows += 1;
-      }
-      // Completely abort the parsing of the file if we've seen more than 1024:
-      return this.numConsecutiveEmptyRows < 1024;
-    }
-    this.numConsecutiveEmptyRows = 0;
-
     if (this.parser) {
       this.parser.parseOpen(node);
       return true;
     } else if (node.name === 'row') {
+      this.numRowsSeen += 1;
+      if (this.numRowsSeen === 65536) {
+        // We've seen some files that have up to a ~a million trailing rows
+        // that only seem to exist as placeholders for custom formats, eg.:
+        //
+        //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //
+        // Avoid spending memory on those rows by skipping them as soon as we
+        // notice that the XML tag is self-closing, and thus cannot contain any
+        // data we're interested in. For one file in particular,
+        // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
+
+        throw new Error('The number of rows exceeds the limit');
+      }
+
       var spans = node.attributes.spans ? node.attributes.spans.split(':').map(function(span) { return parseInt(span, 10); }) : [undefined, undefined];
       var model = this.model = {
         number: parseInt(node.attributes.r, 10),

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -76,24 +76,32 @@ utils.inherits(RowXform, BaseXform, {
   },
   
   parseOpen: function(node) {
+    if (node.name === 'row' && node.isSelfClosing) {
+      // We've seen some files that have up to a ~a million trailing rows
+      // that only seem to exist as placeholders for custom formats, eg.:
+      //
+      //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+      //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+      //
+      // Avoid spending memory on those rows by skipping them as soon as we
+      // notice that the XML tag is self-closing, and thus cannot contain any
+      // data we're interested in. For one file in particular,
+      // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
+
+      if (typeof this.numConsecutiveEmptyRows === 'undefined') {
+        this.numConsecutiveEmptyRows = 1;
+      } else {
+        this.numConsecutiveEmptyRows += 1;
+      }
+      // Completely abort the parsing of the file if we've seen more than 1024:
+      return this.numConsecutiveEmptyRows < 1024;
+    }
+    this.numConsecutiveEmptyRows = 0;
+
     if (this.parser) {
       this.parser.parseOpen(node);
       return true;
     } else if (node.name === 'row') {
-      if (node.isSelfClosing) {
-        // We've seen some files that have up to a ~a million trailing rows
-        // that only seem to exist as placeholders for custom formats, eg.:
-        //
-        //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
-        //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
-        //
-        // Avoid spending memory on those rows by skipping them as soon as we
-        // notice that the XML tag is self-closing, and thus cannot contain any
-        // data we're interested in. For one file in particular,
-        // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
-
-        return false;
-      }
       var spans = node.attributes.spans ? node.attributes.spans.split(':').map(function(span) { return parseInt(span, 10); }) : [undefined, undefined];
       var model = this.model = {
         number: parseInt(node.attributes.r, 10),

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -11,11 +11,12 @@ var BaseXform = require('../base-xform');
 
 var CellXform = require('./cell-xform');
 
-var RowXform = module.exports = function() {
+var RowXform = module.exports = function(maxRows) {
   this.map = {
     c: new CellXform()
   };
   this.numRowsSeen = 0;
+  this.maxRows = typeof maxRows === 'number' ? maxRows : Infinity;
 };
 
 // <row r="<%=row.number%>"
@@ -82,7 +83,7 @@ utils.inherits(RowXform, BaseXform, {
       return true;
     } else if (node.name === 'row') {
       this.numRowsSeen += 1;
-      if (this.numRowsSeen === 65536) {
+      if (this.numRowsSeen === this.maxRows) {
         // We've seen some files that have up to a ~a million trailing rows
         // that only seem to exist as placeholders for custom formats, eg.:
         //

--- a/lib/xlsx/xform/sheet/row-xform.js
+++ b/lib/xlsx/xform/sheet/row-xform.js
@@ -80,6 +80,20 @@ utils.inherits(RowXform, BaseXform, {
       this.parser.parseOpen(node);
       return true;
     } else if (node.name === 'row') {
+      if (node.isSelfClosing) {
+        // We've seen some files that have up to a ~a million trailing rows
+        // that only seem to exist as placeholders for custom formats, eg.:
+        //
+        //   <row r="1047685" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //   <row r="1047686" s="18" customFormat="1" x14ac:dyDescent="0.2"/>
+        //
+        // Avoid spending memory on those rows by skipping them as soon as we
+        // notice that the XML tag is self-closing, and thus cannot contain any
+        // data we're interested in. For one file in particular,
+        // this made the peak utilized JavaScript heap go from 123 MB to 13 MB:
+
+        return false;
+      }
       var spans = node.attributes.spans ? node.attributes.spans.split(':').map(function(span) { return parseInt(span, 10); }) : [undefined, undefined];
       var model = this.model = {
         number: parseInt(node.attributes.r, 10),

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -33,14 +33,15 @@ var AutoFilterXform = require('./auto-filter-xform');
 var PictureXform = require('./picture-xform');
 var DrawingXform = require('./drawing-xform');
 
-var WorkSheetXform = module.exports = function() {
+var WorkSheetXform = module.exports = function(maxRows) {
+console.log('new WorkSheetXorm', maxRows);
   this.map = {
     sheetPr: new SheetPropertiesXform(),
     dimension: new DimensionXform(),
     sheetViews: new ListXform({tag: 'sheetViews', count: false, childXform: new SheetViewXform()}),
     sheetFormatPr: new SheetFormatPropertiesXform(),
     cols: new ListXform({tag: 'cols', count: false, childXform: new ColXform()}),
-    sheetData: new ListXform({tag: 'sheetData', count: false, empty: true, childXform: new RowXform()}),
+    sheetData: new ListXform({tag: 'sheetData', count: false, empty: true, childXform: new RowXform(maxRows)}),
     autoFilter: new AutoFilterXform(),
     mergeCells: new ListXform({tag: 'mergeCells', count: true, childXform: new MergeCellXform()}),
     hyperlinks: new ListXform({tag: 'hyperlinks', count: false, childXform: new HyperlinkXform()}),

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -34,7 +34,6 @@ var PictureXform = require('./picture-xform');
 var DrawingXform = require('./drawing-xform');
 
 var WorkSheetXform = module.exports = function(maxRows) {
-console.log('new WorkSheetXorm', maxRows);
   this.map = {
     sheetPr: new SheetPropertiesXform(),
     dimension: new DimensionXform(),

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -27,8 +27,9 @@ var DrawingXform = require('./xform/drawing/drawing-xform');
 
 var theme1Xml = require('./xml/theme1.js');
 
-var XLSX = module.exports = function(workbook) {
+var XLSX = module.exports = function(workbook, maxRows) {
   this.workbook = workbook;
+  this.maxRows = maxRows;
 };
 
 function fsReadFileAsync(filename, options) {
@@ -81,7 +82,7 @@ XLSX.prototype = {
   },
   reconcile: function(model) {
     var workbookXform = new WorkbookXform();
-    var worksheetXform = new WorksheetXform();
+    var worksheetXform = new WorksheetXform(this.maxRows);
     var drawingXform = new DrawingXform();
 
     workbookXform.reconcile(model);
@@ -132,7 +133,7 @@ XLSX.prototype = {
     var match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
     if (match) {
       var sheetNo = match[1];
-      var xform = new WorksheetXform();
+      var xform = new WorksheetXform(this.maxRows);
       return xform.parseStream(entry)
         .then(function(worksheet) {
           worksheet.sheetNo = sheetNo;
@@ -583,7 +584,7 @@ XLSX.prototype = {
 
     // prepare all of the things before the render
     var workbookXform = new WorkbookXform();
-    var worksheetXform = new WorksheetXform();
+    var worksheetXform = new WorksheetXform(this.maxRows);
 
     workbookXform.prepare(model);
 


### PR DESCRIPTION
Addresses: https://podio.com/peakon/operations/apps/actions/items/81?utm_campaign=member_reference_add

This hack avoids the excessive memory usage when processing the particular file that caused the October 4th OOM incident. Turns out the xl/worksheets/sheet1.xml entry inside it actually contains about a million trailing empty rows, and indeed materializing that as row objects was what was causing the memory problem.

Since the main worksheet XML file unzips to 70 MB, there's still a significant processing time associated with running it through the SAX parser. On my laptop this fix brings down the processing time from ~20 to ~16 seconds. We might be able to do better than that by eg. discarding the rest of the file when we've seen a certain number of consecutive empty rows.

Needless to say, I'm not completely happy with the way this is integrated -- as a minimum it should probably go behind a mode switch of some kind. I can look into that if y'all agree with the overall approach.

@holm, I'm assuming that omitting empty rows occurring between populated rows won't have any adverse effects on the import itself?

Thoughts?